### PR TITLE
Enable multitap (multiplayer5) if a button is pressed on a controller other than 1 or 2

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -296,7 +296,7 @@ void init_sfc_setting(void)
    Settings.DisableMasterVolume = false;
    Settings.Mouse = true;
    Settings.SuperScope = true;
-   Settings.MultiPlayer5 = true;
+   Settings.MultiPlayer5 = false;
    Settings.ControllerOption = SNES_JOYPAD;
 
    Settings.Transparency = true;
@@ -412,8 +412,21 @@ uint32_t S9xReadJoypad(int port)
    uint32_t joypad = 0;
 
    for (i = RETRO_DEVICE_ID_JOYPAD_B; i <= RETRO_DEVICE_ID_JOYPAD_R; i++)
-      if (input_cb(port, RETRO_DEVICE_JOYPAD, 0, i))
-         joypad |= snes_lut[i];
+   {
+	   if (input_cb(port, RETRO_DEVICE_JOYPAD, 0, i))
+	   {
+		   joypad |= snes_lut[i];
+
+		   // DJW If a button was pressed on controller 3 or 4 then we
+		   // want to enable the multitap
+		   if(i > 1 && !Settings.MultiPlayer5)
+		   {
+			   Settings.MultiPlayer5 = true;
+			   Settings.ControllerOption = SNES_MULTIPLAYER5;
+			   IPPU.Controller = SNES_MULTIPLAYER5;
+		   }		 
+	   }
+   }
 
    return joypad;
 }

--- a/source/ppu.c
+++ b/source/ppu.c
@@ -2361,12 +2361,6 @@ static void CommonPPUReset()
    S9xFixColourBrightness();
    IPPU.PreviousLine = IPPU.CurrentLine = 0;
 
-   if (Settings.ControllerOption == 0)
-      IPPU.Controller = SNES_MAX_CONTROLLER_OPTIONS - 1;
-   else
-      IPPU.Controller = Settings.ControllerOption - 1;
-   S9xNextController();
-
    for (c = 0; c < 2; c++)
       memset(&IPPU.Clip [c], 0, sizeof(struct ClipData));
 
@@ -2542,7 +2536,9 @@ void ProcessSuperScope()
    }
 }
 
-void S9xNextController()
+// DJW: Not what why this function exists given that
+// it's only called once unecessarily
+/*void S9xNextController()
 {
    switch (IPPU.Controller)
    {
@@ -2590,6 +2586,7 @@ void S9xNextController()
       break;
    }
 }
+*/
 
 void S9xUpdateJustifiers()
 {


### PR DESCRIPTION
Code was already in place for multitap support (called multiplayer5 in the code) but it was not enabled. Since there is no way to query retroarch for the number of controllers connected, I implemented a change where the multitap becomes enabled if a button is pressed on any controller other than 1 or 2. Note that I didn't simply enable multitap all the time because I've heard that some 1-2 player games will not work properly with multitap enabled, though I don't know which games these are.